### PR TITLE
Help response bug

### DIFF
--- a/config/config.help.command.json
+++ b/config/config.help.command.json
@@ -29,7 +29,7 @@
 			"syntax": "/lunchio remove ban [restaurant]",
 			"description": "Removes a restaurant from your banned list.",
 			"examples": [
-				"/lunchio ban Potbelly"
+				"/lunchio remove ban Potbelly"
 			]
 		},
 		{

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
   },
   "devDependencies": {
     "chai": "^3.5.0",
-    "mocha": "^3.0.2"
+    "mocha": "^3.0.2",
+    "sinon": "^1.17.6"
   },
   "scripts": {
     "test": "mocha --recursive test/specs/",

--- a/src/command/Help.js
+++ b/src/command/Help.js
@@ -103,7 +103,7 @@ module.exports = BaseCmd.extend({
             throw new Error('Username must be provided.');
         }
 
-        var response = _.template("Hi <%= username %>, my name is luncio. I can help you and your friends \
+        var response = _.template("Hi @<%= username %>, my name is luncio. I can help you and your friends \
         find the place for lunch that everyone will enjoy. Get started by adding your favorite \
         restaurants to your profile using: \n*<%= addCmd %>* \nYou can also \
         tell me the restaurants you don't like so I can start to learn more about your food \
@@ -122,7 +122,9 @@ module.exports = BaseCmd.extend({
             helpCmd: '/lunchio'
         };
 
-        return response(data);
+        return {
+            "text": response(data)
+        };
     },
 
     /**
@@ -172,8 +174,8 @@ module.exports = BaseCmd.extend({
 
     /**
      * Returns reponse of all examples
-     * @param  {[type]} examples [description]
-     * @return {[type]}          [description]
+     * @param  {Array} examples Array of example Strings.
+     * @return {String}          Concatenation of all examples, with markup.
      */
     createExamplesResponse: function(examples) {
         var self = this;

--- a/src/command/Help.js
+++ b/src/command/Help.js
@@ -90,6 +90,42 @@ module.exports = BaseCmd.extend({
     },
 
     /**
+     * Returns the initial help response when a user
+     * creates a profile with lunchio.
+     *
+     * Requires a username to address the user directly.
+     * 
+     * @param  {String} username Slack username.
+     * @return {String}          Signup response.
+     */
+    getSignupResponse: function(username) {
+        if (!username) {
+            throw new Error('Username must be provided.');
+        }
+
+        var response = _.template("Hi <%= username %>, my name is luncio. I can help you and your friends \
+        find the place for lunch that everyone will enjoy. Get started by adding your favorite \
+        restaurants to your profile using: \n*<%= addCmd %>* \nYou can also \
+        tell me the restaurants you don't like so I can start to learn more about your food \
+        preferences and only recommend the places you'll enjoy most. I call these your banned \
+        restaurants. Add restaurants to your banned list using: \n*<%= banCmd %>* \n\
+        If you ever want to see what restaurants you've favorited and what you've banned just \
+        ask using: \n*<%= myListCmd %>* \nWhen it's time to go to lunch I can help you \
+        invite your friends using: \n*<%= inviteCmd %>* \nQuestions? Just type *<%= helpCmd %>* in \
+        the message bar and see a list of everything I can do. \nHappy lunching!");
+        var data = {
+            username: username,
+            addCmd: this.getCommandResponse('add place'),
+            banCmd: this.getCommandResponse('ban'),
+            myListCmd: this.getCommandResponse("what's on my list"),
+            inviteCmd: this.getCommandResponse('invite'),
+            helpCmd: '/lunchio'
+        };
+
+        return response(data);
+    },
+
+    /**
      * Retrieves the help response for a specific command.
      *
      * Throws an error if given command cannot be found.

--- a/src/core/CommandResponse.js
+++ b/src/core/CommandResponse.js
@@ -15,12 +15,12 @@ module.exports = Class.extend({
     // Private properties
     _defr: null,
     _text: '',
-    _attachements:[],
+    _attachments:[],
 
     public: false,
 
     initialize: function() {
-        this.__attachements = [];
+        this.__attachments = [];
     },
 
     addAttachment: function(attement){
@@ -29,7 +29,7 @@ module.exports = Class.extend({
             return this;
         }
 
-        this._attachements.push(attement);
+        this._attachments.push(attement);
 
         return this;
     },
@@ -51,8 +51,8 @@ module.exports = Class.extend({
             text: text,
         };
 
-        if (!_.isEmpty(this._attachements)) {
-            data.attachements = this._attachements;
+        if (!_.isEmpty(this._attachments)) {
+            data.attachments = this._attachments;
         }
 
         if (this.public) {
@@ -71,7 +71,7 @@ module.exports = Class.extend({
     toString: function(){
         var map = {
             public: this.public,
-            attachements: this.attachements,
+            attachments: this.attachments,
         };
         return pretty_json(map);
     }

--- a/test/specs/command/Help.spec.js
+++ b/test/specs/command/Help.spec.js
@@ -16,21 +16,24 @@ describe('Help Command test', function() {
 		command = new HelpCommand();
 	});
 
-	describe('Tests for createCommandResponse', function() {
+	describe('Tests for createCommandResponseObject', function() {
 
 		it('Returns Reference error for missing description', function() {
-			var data = {};
+			var data = {syntax: 'Some syntax'};
+			var response = {
+				"title": undefined,
+				"text": "Some syntax \n",
+				"mrkdwn_in": ["text"]
+			};
 
-		 	assert.throws(function() {
-		 		command.createCommandResponse(data)
-		 	}, ReferenceError, 'description is not defined');
+		 	assert.deepEqual(command.createCommandResponseObject(data), response);
 		});
 
 		it('Returns Reference error for missing syntax', function() {
 			var data = {description: 'Some description'};
 
 		 	assert.throws(function() {
-		 		command.createCommandResponse(data)
+		 		command.createCommandResponseObject(data)
 		 	}, ReferenceError, 'syntax is not defined');
 		});
 
@@ -40,7 +43,7 @@ describe('Help Command test', function() {
 
 			// Examples are defaulted to an empty string
 		 	assert.doesNotThrow(function() {
-		 		command.createCommandResponse(data)
+		 		command.createCommandResponseObject(data)
 		 	}, ReferenceError, 'examples is not defined');
 		});
 
@@ -48,56 +51,66 @@ describe('Help Command test', function() {
 			var data = {description: null,
 						syntax: null,
 						examples: null};
-			var template = '> ** \n>  \n> ';
+			var responseObj = {
+				"title": null,
+				"text": " \n",
+				"mrkdwn_in": [
+	                "text"
+	            ]
+			};
 
-		 	assert.equal(command.createCommandResponse(data), template);
+		 	assert.deepEqual(command.createCommandResponseObject(data), responseObj);
 		});
 
 		it('Returns response with data filled in.', function() {
 			var data = {description: 'test001',
 						syntax: 'test002',
 						examples: ['test003']};
-			var template = '> *test001* \n> test002 \n> Example: `test003`\n';
+			var responseObj = {
+				"title": "test001",
+				"text": "test002 \nExample: `test003`\n",
+				"mrkdwn_in": ["text"]
+			};
 
-		 	assert.equal(command.createCommandResponse(data), template);
+		 	assert.deepEqual(command.createCommandResponseObject(data), responseObj);
 		});
 	});
 
-	describe('Tests for createExampleResponse', function() {
+	describe('Tests for addExampleResponse', function() {
 
 		it('Returns String with two backticks given null value.', function() {
-			assert.equal(command.addExampleResponse(null), '');
+			assert.equal(command.addExampleResponse(null), "");
 		});
 
 		it('Returns input String between two backticks', function () {
-			assert.equal(command.addExampleResponse('test001'), 'Example: `test001`');
+			assert.equal(command.addExampleResponse('test001'), "Example: `test001`");
 		});
 
 		it('Returns input Number between two backticks', function () {
-			assert.equal(command.addExampleResponse(42), 'Example: `42`');
+			assert.equal(command.addExampleResponse(42), "Example: `42`");
 		});
 	});
 
 	describe('Tests for createExamplesResponse', function() {
 
 		it('Returns empty string given null value.', function() {
-			assert.equal(command.createExamplesResponse(null), '');
+			assert.equal(command.createExamplesResponse(null), "");
 		});
 
 		it('Returns empty string given empty list of examples.', function() {
-			assert.equal(command.createExamplesResponse([]), '');
+			assert.equal(command.createExamplesResponse([]), "");
 		});
 
 		it('Returns single example, between backticks.', function() {
 			var data = ['test001'];
 
-			assert.equal(command.createExamplesResponse(data), 'Example: `test001`\n');
+			assert.equal(command.createExamplesResponse(data), "Example: `test001`\n");
 		});
 
 		it('Returns multiple example, between backticks.', function() {
 			var data = ['test001', 'test002'];
 
-			assert.equal(command.createExamplesResponse(data), 'Example: `test001`\nExample: `test002`\n');
+			assert.equal(command.createExamplesResponse(data), "Example: `test001`\nExample: `test002`\n");
 		});
 	});
 
@@ -114,7 +127,7 @@ describe('Help Command test', function() {
 		it('Returns correct response object', function() {
 			var cmdName = 'testCmd001';
 			var expected = {
-				text: '> *This is testCmd001* \n> /bot testCmd001 \n> '
+				text: '*This is testCmd001* \n/bot testCmd001 \n'
 			};
 
 			assert.deepEqual(command.getCommandResponse(cmdName), expected);
@@ -123,7 +136,7 @@ describe('Help Command test', function() {
 		it('Returns correct response object with examples', function() {
 			var cmdName = 'testCmd002';
 			var expected = {
-				text: '> *This is testCmd002* \n> /bot testCmd002 <param1> \n> Example: `/bot testCmd002 p1`\nExample: `/bot testCmd002 p2`\n'
+				text: '*This is testCmd002* \n/bot testCmd002 <param1> \nExample: `/bot testCmd002 p1`\nExample: `/bot testCmd002 p2`\n'
 			};
 
 			assert.deepEqual(command.getCommandResponse(cmdName), expected);
@@ -136,8 +149,16 @@ describe('Help Command test', function() {
 
 			expected.text = 'Lunch.io is a tool that can help your team choose a lunch destination faster.';
 			expected.attachments = [ 
-				{ text: '> *This is testCmd001* \n> /bot testCmd001 \n> ' },
-			    { text: '> *This is testCmd002* \n> /bot testCmd002 <param1> \n> Example: `/bot testCmd002 p1`\nExample: `/bot testCmd002 p2`\n'}
+				{ 
+					"title": "This is testCmd001",
+					"text": "/bot testCmd001 \n",
+					"mrkdwn_in": ["text"]
+				},
+			    { 
+			    	"title": "This is testCmd002",
+			    	"text": "/bot testCmd002 <param1> \nExample: `/bot testCmd002 p1`\nExample: `/bot testCmd002 p2`\n",
+					"mrkdwn_in": ["text"]
+			    }
 			];
 
 			assert.deepEqual(command.getOutput(), expected);

--- a/test/specs/command/Help.spec.js
+++ b/test/specs/command/Help.spec.js
@@ -51,7 +51,7 @@ describe('Help Command test', function() {
 		it('Returns response with no data filled in', function() {
 			var data = {description: null,
 						syntax: null,
-						examples: null};
+						examples: null};;
 			var responseObj = {
 				"title": null,
 				"text": " \n",
@@ -67,9 +67,11 @@ describe('Help Command test', function() {
 			var data = {description: 'test001',
 						syntax: 'test002',
 						examples: ['test003']};
+			var stub = sinon.stub(command, "createExamplesResponse");
+			stub.returns("examplesResponse");
 			var responseObj = {
 				"title": "test001",
-				"text": "test002 \nExample: `test003`\n",
+				"text": "test002 \nexamplesResponse",
 				"mrkdwn_in": ["text"]
 			};
 
@@ -104,14 +106,18 @@ describe('Help Command test', function() {
 
 		it('Returns single example, between backticks.', function() {
 			var data = ['test001'];
+			var stub = sinon.stub(command, "addExampleResponse");
+			stub.returns("exampleResponse");
 
-			assert.equal(command.createExamplesResponse(data), "Example: `test001`\n");
+			assert.equal(command.createExamplesResponse(data), "exampleResponse\n");
 		});
 
 		it('Returns multiple example, between backticks.', function() {
 			var data = ['test001', 'test002'];
+			var stub = sinon.stub(command, "addExampleResponse");
+			stub.returns("exampleResponse");
 
-			assert.equal(command.createExamplesResponse(data), "Example: `test001`\nExample: `test002`\n");
+			assert.equal(command.createExamplesResponse(data), "exampleResponse\nexampleResponse\n");
 		});
 	});
 
@@ -175,11 +181,11 @@ describe('Help Command test', function() {
 			}, Error, 'Username must be provided.');
 		});
 
-		it.only('Returns full signup response', function() {
+		it('Returns full signup response', function() {
 			var username = 'testUser001';
 			var stub = sinon.stub(command, "getCommandResponse");
 			stub.returns("testCmdResponse");
-			var expected = "Hi testUser001, my name is luncio. I can help you and your friends \
+			var expectedText = "Hi @testUser001, my name is luncio. I can help you and your friends \
 	        find the place for lunch that everyone will enjoy. Get started by adding your favorite \
 	        restaurants to your profile using: \n*testCmdResponse* \nYou can also \
 	        tell me the restaurants you don't like so I can start to learn more about your food \
@@ -189,9 +195,11 @@ describe('Help Command test', function() {
 	        ask using: \n*testCmdResponse* \nWhen it's time to go to lunch I can help you \
 	        invite your friends using: \n*testCmdResponse* \nQuestions? Just type */lunchio* in \
 	        the message bar and see a list of everything I can do. \nHappy lunching!";
-	        expected = expected.replace(/\t/g,'');
+	        expected = {
+	        	"text": expectedText.replace(/\t/g,'')
+	        };
 
-	        assert.equal(command.getSignupResponse(username), expected);
+	        assert.deepEqual(command.getSignupResponse(username), expected);
 		});
 	});
 });

--- a/test/specs/command/Help.spec.js
+++ b/test/specs/command/Help.spec.js
@@ -5,6 +5,7 @@
 require('rootpath')();
 
 var assert = require('chai').assert;
+var sinon = require('sinon');
 var HelpCommand = require('src/command/Help');
 var config = require('config/config.help.command.json');
 
@@ -162,6 +163,35 @@ describe('Help Command test', function() {
 			];
 
 			assert.deepEqual(command.getOutput(), expected);
+		});
+	});
+
+	describe('Tests for getSignupResponse', function() {
+		it('Returns error if no username is provided', function() {
+			var username = null;
+
+			assert.throws(function() {
+				command.getSignupResponse(username);
+			}, Error, 'Username must be provided.');
+		});
+
+		it.only('Returns full signup response', function() {
+			var username = 'testUser001';
+			var stub = sinon.stub(command, "getCommandResponse");
+			stub.returns("testCmdResponse");
+			var expected = "Hi testUser001, my name is luncio. I can help you and your friends \
+	        find the place for lunch that everyone will enjoy. Get started by adding your favorite \
+	        restaurants to your profile using: \n*testCmdResponse* \nYou can also \
+	        tell me the restaurants you don't like so I can start to learn more about your food \
+	        preferences and only recommend the places you'll enjoy most. I call these your banned \
+	        restaurants. Add restaurants to your banned list using: \n*testCmdResponse* \n\
+	        If you ever want to see what restaurants you've favorited and what you've banned just \
+	        ask using: \n*testCmdResponse* \nWhen it's time to go to lunch I can help you \
+	        invite your friends using: \n*testCmdResponse* \nQuestions? Just type */lunchio* in \
+	        the message bar and see a list of everything I can do. \nHappy lunching!";
+	        expected = expected.replace(/\t/g,'');
+
+	        assert.equal(command.getSignupResponse(username), expected);
 		});
 	});
 });

--- a/test/specs/core/CommandResponse.spec.js
+++ b/test/specs/core/CommandResponse.spec.js
@@ -45,13 +45,13 @@ describe('CommandResponse', function(){
 
         resp.onSend(function(data){
 
-            var at1 = data.attachements[0].text;
-            var at2 = data.attachements[1].text;
+            var at1 = data.attachments[0].text;
+            var at2 = data.attachments[1].text;
 
             log.info("callback data: ", data);
             assert.isTrue(data.text == 'cool');
             assert.isTrue(data.response_type == 'in_channel');
-                assert.isTrue(data.attachements.length == 2);
+                assert.isTrue(data.attachments.length == 2);
 
             assert.isTrue(at1 == 'mango');
             assert.isTrue(at2 == 'sushi');


### PR DESCRIPTION
The existing help code only emits a brief description of what lunch.io does. 

These changes allow the attachments to be sent down properly as well. Additionally, they have been reformatted using Slack's attachment formatting markup and JSON structure.

BUG: I noticed that attachments was misspelled in the CommandResponse class, so I have updated that as well.
